### PR TITLE
Add Laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,18 +16,18 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/database": "^11.0|^12.0",
-        "illuminate/support": "^11.0|^12.0"
+        "illuminate/database": "^11.0|^12.0|^13.0",
+        "illuminate/support": "^11.0|^12.0|^13.0"
     },
     "require-dev": {
         "larastan/larastan": "^3.0",
         "laravel/pint": "^1.5",
         "mockery/mockery": "^1.6.6",
         "php-coveralls/php-coveralls": "^2.4",
-        "phpunit/phpunit": "^10.5",
-        "reedware/laravel-relation-joins": "^8.0",
+        "phpunit/phpunit": "^10.5|^11.5|^12.5",
+        "reedware/laravel-relation-joins": "^8.0|^9.0",
         "reedware/sail-lite": "^1.3",
-        "symfony/var-dumper": "^7.0"
+        "symfony/var-dumper": "^7.0|^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Concerns/RunsIntegrationQueries.php
+++ b/tests/Concerns/RunsIntegrationQueries.php
@@ -3,7 +3,9 @@
 namespace Reedware\LaravelCompositeRelations\Tests\Concerns;
 
 use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Connection;
 use Illuminate\Database\Eloquent\Model as Eloquent;
+use Illuminate\Database\Schema\Builder;
 use Reedware\LaravelCompositeRelations\Tests\EloquentTaskModelStub;
 
 trait RunsIntegrationQueries
@@ -11,7 +13,7 @@ trait RunsIntegrationQueries
     /**
      * The database connection implementation.
      *
-     * @var \Illuminate\Database\Connection
+     * @var Connection
      */
     protected $db;
 
@@ -132,7 +134,7 @@ trait RunsIntegrationQueries
     /**
      * Get a schema builder instance.
      *
-     * @return \Illuminate\Database\Schema\Builder
+     * @return Builder
      */
     protected function schema()
     {
@@ -142,7 +144,7 @@ trait RunsIntegrationQueries
     /**
      * Get a database connection instance.
      *
-     * @return \Illuminate\Database\Connection
+     * @return Connection
      */
     protected function connection()
     {


### PR DESCRIPTION
## Summary

Adds Laravel 13 support by allowing illuminate/database and illuminate/support version constraint ^13.0.

Also relaxes compatible dev dependency constraints so the package can be resolved and checked with the Laravel 13 ecosystem:

- phpunit/phpunit: ^10.5|^11.5|^12.5
- reedware/laravel-relation-joins: ^8.0|^9.0
- symfony/var-dumper: ^7.0|^8.0

## Validation

- composer update -W resolves successfully with illuminate/database v13.5.0 and illuminate/support v13.5.0
- vendor/bin/phpstan analyse --memory-limit=1G passes
- vendor/bin/pint --test --dirty passes

I was not able to complete the PHPUnit integration suite in my local WSL environment because the PHP runtime is missing the pdo_sqlite extension, and the suite uses SQLite :memory: connections.